### PR TITLE
streaming logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ func main() {
 	defer appResources.DockerCli.Close()
 
 	jobs_ch := make(chan types.JobRequest, jobsCapacity)
-	results_ch := make(chan types.JobResult, jobsCapacity)
+	results_ch := make(chan types.StreamingJobResult, jobsCapacity)
 	var wg sync.WaitGroup
 
 	// Start a goroutine to receive jobs from RabbitMQ

--- a/python_testing/producer.py
+++ b/python_testing/producer.py
@@ -17,7 +17,7 @@ go_snippets = [
     'package main\nimport "fmt"\nfunc main() { fmt.Println("Upper:", "hello world") }',
     'package main\nimport "fmt"\nfunc main() { fmt.Println("Sum:", 10+20) }',
     'package main\nimport "fmt"\nfunc main() { fmt.Println("Bool:", true && false) }',
-    'package main\nimport "fmt"\nfunc main() { fmt.Println(fib(20000000))}\nfunc fib(n int) int { f1:=0; f2:=1; for i := 0; i < n; i++ { f1,f2 = f2, f1+f2; fmt.Println(f1) }; return f1 }',
+    'package main\nimport "fmt"\nfunc main() { fmt.Println(fib(100))}\nfunc fib(n int) int { f1:=0; f2:=1; for i := 0; i < n; i++ { f1,f2 = f2, f1+f2; fmt.Println(f1) }; return f1 }',
 ]
 
 # Connect to RabbitMQ
@@ -33,7 +33,7 @@ for i, code in enumerate(go_snippets, start=1):
     job = {
         "ProblemId": i,
         "Code": code,
-        "UserId": 1
+        "UserId": 2
 
     }
     body = json.dumps(job)

--- a/python_testing/producer.py
+++ b/python_testing/producer.py
@@ -17,6 +17,7 @@ go_snippets = [
     'package main\nimport "fmt"\nfunc main() { fmt.Println("Upper:", "hello world") }',
     'package main\nimport "fmt"\nfunc main() { fmt.Println("Sum:", 10+20) }',
     'package main\nimport "fmt"\nfunc main() { fmt.Println("Bool:", true && false) }',
+    'package main\nimport "fmt"\nfunc main() { fmt.Println(fib(20000000))}\nfunc fib(n int) int { f1:=0; f2:=1; for i := 0; i < n; i++ { f1,f2 = f2, f1+f2; fmt.Println(f1) }; return f1 }',
 ]
 
 # Connect to RabbitMQ

--- a/results/handler.go
+++ b/results/handler.go
@@ -9,7 +9,7 @@ import (
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
-func Handle(ctx context.Context, results <-chan types.JobResult) {
+func Handle(ctx context.Context, results <-chan types.StreamingJobResult) {
 	// Connect to RabbitMQ
 	conn, err := amqp.Dial("amqp://guest:guest@localhost:5672/")
 	if err != nil {

--- a/types/job.go
+++ b/types/job.go
@@ -13,17 +13,16 @@ type JobRequest struct {
 	UserId    int
 }
 
-type StreamingJobResult struct {
-	JobId  int
-	Result StreamingResult
-	UserId int
-	Done   bool
+type StreamingEvent struct {
+	Kind    string // "stdout" | "stderr" | "error"
+	Message string
 }
 
-type StreamingResult struct {
-	Stdout []string
-	Stderr []string
-	Error  string
+type StreamingJobResult struct {
+	JobId         int
+	Events        []StreamingEvent
+	UserId        int
+	SequenceIndex int
 }
 
 type WorkerConfig struct {

--- a/types/job.go
+++ b/types/job.go
@@ -13,16 +13,17 @@ type JobRequest struct {
 	UserId    int
 }
 
-type JobResult struct {
+type StreamingJobResult struct {
 	JobId  int
-	Result Result
+	Result StreamingResult
 	UserId int
+	Done   bool
 }
 
-type Result struct {
-	Stdout string
-	Stderr string
-	Err    string
+type StreamingResult struct {
+	Stdout []string
+	Stderr []string
+	Error  string
 }
 
 type WorkerConfig struct {
@@ -30,5 +31,5 @@ type WorkerConfig struct {
 	DockerCli *client.Client
 	Wg        *sync.WaitGroup
 	Jobs      <-chan JobRequest
-	Results   chan<- JobResult
+	Results   chan<- StreamingJobResult
 }

--- a/worker/manager.go
+++ b/worker/manager.go
@@ -2,7 +2,9 @@ package worker
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"sync"
 	"time"
 
 	"github.com/DistCodeP7/distcode_worker/types"
@@ -28,7 +30,6 @@ func StartWorker(config *types.WorkerConfig, workerID int) {
 		select {
 		case job, ok := <-config.Jobs:
 			if !ok {
-
 				log.Printf("Worker %d shutting down as jobs channel is closed.", workerID)
 				return
 			}
@@ -36,27 +37,100 @@ func StartWorker(config *types.WorkerConfig, workerID int) {
 
 			execCtx, cancelExec := context.WithTimeout(config.Ctx, 30*time.Second)
 
-			stdout, stderr, err := w.ExecuteCode(execCtx, job.Code)
-			config.Results <- types.JobResult{
+			stdoutCh := make(chan string)
+			stderrCh := make(chan string)
+
+			var (
+				stdoutBuf []string
+				stderrBuf []string
+				muStdout  sync.Mutex
+				muStderr  sync.Mutex
+			)
+
+			go func() {
+				for line := range stdoutCh {
+					muStdout.Lock()
+					stdoutBuf = append(stdoutBuf, line)
+					muStdout.Unlock()
+				}
+			}()
+
+			go func() {
+				for line := range stderrCh {
+					muStderr.Lock()
+					stderrBuf = append(stderrBuf, line)
+					muStderr.Unlock()
+				}
+			}()
+
+			go func() {
+				ticker := time.NewTicker(100 * time.Millisecond)
+				defer ticker.Stop()
+
+				for {
+					select {
+					case <-execCtx.Done():
+						return
+					case <-ticker.C:
+						muStdout.Lock()
+						outCopy := append([]string(nil), stdoutBuf...)
+						stdoutBuf = nil
+						muStdout.Unlock()
+
+						muStderr.Lock()
+						errCopy := append([]string(nil), stderrBuf...)
+						stderrBuf = nil
+						muStderr.Unlock()
+
+						if len(outCopy) > 0 || len(errCopy) > 0 {
+							config.Results <- types.StreamingJobResult{
+								JobId:  job.ProblemId,
+								UserId: job.UserId,
+								Result: types.StreamingResult{
+									Stdout: outCopy,
+									Stderr: errCopy,
+									Error:  "",
+								},
+							}
+						}
+					}
+				}
+			}()
+
+			err := w.ExecuteCode(execCtx, job.Code, stdoutCh, stderrCh)
+			cancelExec()
+			muStdout.Lock()
+			outCopy := append([]string(nil), stdoutBuf...)
+			stdoutBuf = nil
+			muStdout.Unlock()
+
+			muStderr.Lock()
+			errCopy := append([]string(nil), stderrBuf...)
+			stderrBuf = nil
+			muStderr.Unlock()
+
+			config.Results <- types.StreamingJobResult{
 				JobId:  job.ProblemId,
 				UserId: job.UserId,
-				Result: types.Result{
-					Stdout: stdout,
-					Stderr: stderr,
-					Err: func() string {
-						if err != nil {
-							return err.Error()
-						}
-						return ""
-					}(),
+				Result: types.StreamingResult{
+					Stdout: outCopy,
+					Stderr: errCopy,
+					Error:  errString(err),
 				},
 			}
-			cancelExec()
+
+			fmt.Println("Execution finished with error:", err)
 
 		case <-config.Ctx.Done():
-
 			log.Printf("Worker %d received shutdown signal. Exiting.", workerID)
 			return
 		}
 	}
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }


### PR DESCRIPTION
Stdout and Stderr are published to the MQ at a interval (batching). I don't care what we set the interval at, but currently we publish every 50ms.

The changes primarily reflect changes related to the Result of a worker jobs now being a stream instead of simply taking from the buffers as previous.
