### PR TITLE
gvisor implementation

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -41,6 +41,7 @@ func New(ctx context.Context, cli *client.Client) (*Worker, error) {
 
 	hostConfig := &container.HostConfig{
 		NetworkMode: "none",
+		Runtime: "runsc",
 		Mounts: []mount.Mount{
 			{
 				Type:   mount.TypeBind,


### PR DESCRIPTION
This pull request introduces a minor configuration change to the container setup in the `worker/worker.go` file. The update specifies the use of the `runsc` runtime for containers.

* Container configuration: Added the `Runtime: "runsc"` option to the `container.HostConfig` for enhanced container isolation or compatibility.

DO NOT MEREGE THIS PR